### PR TITLE
fix little endian error in cost function and copy angles

### DIFF
--- a/openquantumcomputing/QAOABase.py
+++ b/openquantumcomputing/QAOABase.py
@@ -82,7 +82,7 @@ class QAOABase:
                 E = 0
                 E2 = 0
                 for string in counts:
-                    cost = self.cost(string, params)
+                    cost = self.cost(string[::-1], params)
                     E += cost*counts[string]
                     E2 += cost**2*counts[string];
                 if n_shots == 1:
@@ -99,7 +99,7 @@ class QAOABase:
             E = 0
             E2 = 0
             for string in counts_list:
-                cost = self.cost(string, params)
+                cost = self.cost(string[::-1], params)
                 E += cost*counts_list[string]
                 E2 += cost**2*counts_list[string];
             if n_shots == 1:
@@ -131,7 +131,7 @@ class QAOABase:
         """
         depth=len(angles)
         tmp=np.zeros(len(angles)+2)
-        tmp[1:-1]=angles
+        tmp[1:-1]=angles.copy()
         w=np.arange(0,depth+1)
         return w/depth*tmp[:-1] + (depth-w)/depth*tmp[1:]
 


### PR DESCRIPTION
qiskit.result.Result.get_counts() returns little endian string -> calculate cost of reversed binary string.

copy angles to be sure that tmp not affects angles.