### PR TITLE
fix error in calculating B_next

### DIFF
--- a/openquantumcomputing/mixer_utilities.py
+++ b/openquantumcomputing/mixer_utilities.py
@@ -257,10 +257,8 @@ def get_A_n(w, z):
     A_curr=get_A1(w, z)
     B_curr=get_B1(w, z)
     for n in range(1, len(z)):
-        x=z[n]
-        y=w[n]
-        A_curr=get_A_next(x,y,A_curr,B_curr)
-        B_curr=get_B_next(x,y,A_curr,B_curr)
+        x, y=z[n], w[n]
+        A_curr, B_curr=get_A_next(x,y,A_curr,B_curr), get_B_next(x,y,A_curr,B_curr)
     return A_curr
 
 def get_Pauli_string_with_algorithm3(B, T):


### PR DESCRIPTION
B_curr is calculated according to: (line 262, 263), which looks like this:
`a=f(a, b)`
`b=g(a, b)`
Here g(a, b) uses the updated a to calculate b. However it should have used the a from the previous iteration.

**Fix**:
`a, b=f(a, b), g(a, b)`
is the same as
`a_next=f(a_prev, b_prev)`
`b_next=g(a_prev, b_prev)`
`a_prev=a_next`
`b_prev=b_next`


